### PR TITLE
fix (protoc-gen-twirpy): service url is not compatible with golang server

### DIFF
--- a/protoc-gen-twirpy/generator/generator.go
+++ b/protoc-gen-twirpy/generator/generator.go
@@ -43,7 +43,7 @@ func GenerateTwirpFile(fd *descriptor.FileDescriptorProto) (*plugin.CodeGenerato
 
 	svcs := fd.GetService()
 	for _, svc := range svcs {
-		svcURL := fmt.Sprintf("%s.%s", fd.GetPackage(), svc.GetName())
+		svcURL := fmt.Sprintf("%s.%s", fd.GetPackage(), CamelCase(svc.GetName()))
 		twirpSvc := &TwirpService{
 			Name:       svc.GetName(),
 			ServiceURL: svcURL,

--- a/protoc-gen-twirpy/generator/helper.go
+++ b/protoc-gen-twirpy/generator/helper.go
@@ -1,0 +1,44 @@
+package generator
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"unicode"
+)
+
+// An alternative of the function 'CamelCase' in a private package:
+// https://github.com/twitchtv/twirp/blob/master/internal/gen/stringutils/stringutils.go
+func CamelCase(s string) string {
+
+	const Delemeter = '_'
+
+	writer := bytes.NewBuffer(make([]byte, 0, len(s)))
+	reader := strings.NewReader(s)
+
+	var prev rune
+	for {
+		r, _, err := reader.ReadRune()
+		if err == io.EOF {
+			break
+		}
+
+		if prev == 0x00 && r == Delemeter {
+			writer.WriteRune('X')
+
+		} else if unicode.IsLower(r) && (prev == 0x00 || prev == Delemeter || (prev >= '0' && prev <= '9')) {
+			if lastIndex := writer.Len() - 1; lastIndex >= 0 && writer.Bytes()[lastIndex] == Delemeter {
+				writer.Truncate(lastIndex) // remove delemeter before symbol
+			}
+			writer.WriteRune(unicode.ToUpper(r))
+
+		} else {
+			writer.WriteRune(r)
+
+		}
+
+		prev = r
+	}
+
+	return writer.String()
+}

--- a/protoc-gen-twirpy/generator/helper_test.go
+++ b/protoc-gen-twirpy/generator/helper_test.go
@@ -1,0 +1,43 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCamelCase(t *testing.T) {
+
+	for src, res := range map[string]string{
+		"_":            "X",
+		"__":           "X_",
+		"___":          "X__",
+		"_1":           "X1",
+		"_a":           "XA",
+		"_aX":          "XAX",
+		"_AX":          "XAX",
+		"1AX":          "1AX",
+		"AX":           "AX",
+		"text":         "Text",
+		"text_":        "Text_",
+		"text__":       "Text__",
+		"text1":        "Text1",
+		"text1_":       "Text1_",
+		"text1a":       "Text1A",
+		"text_a":       "TextA",
+		"text_abc":     "TextAbc",
+		"text1abc":     "Text1Abc",
+		"text_1abc":    "Text_1Abc",
+		"text__1abc":   "Text__1Abc",
+		"_text1abc":    "XText1Abc",
+		"__text1abc":   "XText1Abc",
+		"___text1abc":  "X_Text1Abc",
+		"__1text1abc":  "X_1Text1Abc",
+		"___1text1abc": "X__1Text1Abc",
+		"1text1abc":    "1Text1Abc",
+		"1_text1abc":   "1Text1Abc",
+	} {
+
+		require.Equal(t, res, CamelCase(src), src)
+	}
+}

--- a/protoc-gen-twirpy/go.mod
+++ b/protoc-gen-twirpy/go.mod
@@ -4,5 +4,6 @@ go 1.13
 
 require (
 	github.com/golang/protobuf v1.4.2
+	github.com/stretchr/testify v1.6.0
 	google.golang.org/protobuf v1.23.0
 )

--- a/protoc-gen-twirpy/go.sum
+++ b/protoc-gen-twirpy/go.sum
@@ -1,3 +1,5 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
@@ -7,8 +9,15 @@ github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/verloop/twirpy v0.0.0-20200412151843-f1b8d3e4ddaa h1:JWayDY76T33ESR/FpOwj5a1nzPH96TAAqK+M20UlA6k=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.0 h1:jlIyCplCJFULU/01vCkhKuTyc3OorI3bJFuw6obfgho=
+github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
@@ -17,3 +26,7 @@ google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miE
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
twirp does't use original service name from protobuf:
https://github.com/twitchtv/twirp/blob/master/protoc-gen-twirp_python/main.go#L142
But it's in a private package. So I created a compatible version.