### PR TITLE
Bugfix: Return proper error

### DIFF
--- a/twirp/errors.py
+++ b/twirp/errors.py
@@ -20,10 +20,6 @@ class Errors(Enum):
     DataLoss = "data_loss"
     NoError = ""
 
-    @classmethod
-    def has_value(cls, value):
-        return value in cls._value2member_map_
-
     @staticmethod
     def get_status_code(code):
         return {

--- a/twirp/errors.py
+++ b/twirp/errors.py
@@ -20,6 +20,10 @@ class Errors(Enum):
     DataLoss = "data_loss"
     NoError = ""
 
+    @classmethod
+    def has_value(cls, value):
+        return value in cls._value2member_map_
+
     @staticmethod
     def get_status_code(code):
         return {

--- a/twirp/exceptions.py
+++ b/twirp/exceptions.py
@@ -17,6 +17,8 @@ class TwirpServerException(httplib.HTTPException):
     def __init__(self, *args, code, message, meta={}):
         if isinstance(code, errors.Errors):
             self._code = code
+        if errors.Errors.has_value(code):
+            self._code = errors.Errors(code)
         else:
             self._code = errors.Errors.Unknown
         self._message = message

--- a/twirp/exceptions.py
+++ b/twirp/exceptions.py
@@ -15,11 +15,9 @@ from . import errors
 
 class TwirpServerException(httplib.HTTPException):
     def __init__(self, *args, code, message, meta={}):
-        if isinstance(code, errors.Errors):
-            self._code = code
-        if errors.Errors.has_value(code):
+        try:
             self._code = errors.Errors(code)
-        else:
+        except ValueError:
             self._code = errors.Errors.Unknown
         self._message = message
         self._meta = meta


### PR DESCRIPTION
- Bug: 

client side errors were not getting properly mapped to the Twirp errors and defaulting to the `Unknown` error 

- To Reproduce:

return any error from the server and client will print as `unknown`

- Cause:

When response status is not 200, we generate an error calling [TwirpServerException.from_json](https://github.com/verloop/twirpy/blob/9a3acf146d8dad7022a8bad7a9219dee7795cf3d/twirp/client.py#L26), to this method, we send the error code as strings like `invalid_argument` or `permission_denied`. If you check [TwirpServerException](https://github.com/verloop/twirpy/blob/9a3acf146d8dad7022a8bad7a9219dee7795cf3d/twirp/exceptions.py#L18)'s constructor, it sorta expects code to be of `error.Errors` instance, if not, it defaults to `Errors.Unknown` error.