### PR TITLE
Update package settings to display proper README on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,14 @@ from setuptools import setup
 with open('version.txt') as f:
     version = f.read().strip()
 
+with open('README.md', encoding='utf-8') as f:
+      long_description = f.read().strip()
+
 setup(name="twirp",
       version=version,
       description="Twirp server and client lib",
+      long_description=long_description,
+      long_description_content_type='text/markdown',
       licesnse='unlicense',
       packages=['twirp'],
       install_requires=[


### PR DESCRIPTION
Currently, our PyPI page does not display any helpful info - https://pypi.org/project/twirp/0.0.2/

This PR lets us to display our README contents on PyPI page.