### PR TITLE
python3 errors should convert to strings via str() rather than e.message

### DIFF
--- a/twirp/client.py
+++ b/twirp/client.py
@@ -28,12 +28,12 @@ class TwirpClient(object):
         except requests.exceptions.Timeout as e:
             raise exceptions.TwirpServerException(
                 code=errors.Errors.DeadlineExceeded,
-                message=e.message,
+                message=str(e),
                 meta={"original_exception": e},
             )
         except requests.exceptions.ConnectionError as e:
             raise exceptions.TwirpServerException(
                 code=errors.Errors.Unavailable,
-                message=e.message,
+                message=str(e),
                 meta={"original_exception": e},
             )


### PR DESCRIPTION
Closes #33

Resolves an undesired `AttributeError` which obscures the underlying `ConnectionError`.