### PR TITLE
Respond with BadRoute instead of Internal error by fixing bug with content-type evaluation

### DIFF
--- a/twirp/base.py
+++ b/twirp/base.py
@@ -91,7 +91,7 @@ class TwirpBaseApp(object):
         return value.SerializeToString(), {"Content-Type": "application/protobuf"}
 
     def _get_encoder_decoder(self, endpoint, headers):
-        ctype = headers.get('content-type', None)
+        ctype = headers.get('content-type', '')
         if "application/json" == ctype:
             decoder = functools.partial(self.json_decoder, data_obj=endpoint.input)
             encoder = functools.partial(self.json_encoder, data_obj=endpoint.output)


### PR DESCRIPTION
Fix for Issue #46.  Instead of defaulting content-type to None in _get_encoder_decoder, instead default it to an empty string.  If the content-type header is missing, then the error message will be `unexpected Content-Type: ` instead of raising a type error when attempting to concatenate None to a str.