### PR TITLE
Only generate when there are services

### DIFF
--- a/protoc-gen-twirpy/generator/generator.go
+++ b/protoc-gen-twirpy/generator/generator.go
@@ -24,6 +24,10 @@ func Generate(r *plugin.CodeGeneratorRequest) *plugin.CodeGeneratorResponse {
 			return resp
 		}
 
+		if len(fd.GetService()) == 0 {
+			continue
+		}
+
 		twirpFile, err := GenerateTwirpFile(fd)
 		if err != nil {
 			resp.Error = proto.String("File[" + fileName + "][generate]: " + err.Error())


### PR DESCRIPTION

### Problem
When using the `protoc --twirpy_out` command to generate Python Twirp API code, the plugin generates an empty file for any .proto file that has no services defined. This behavior can be inconvenient and confusing, especially in large projects where many proto files are present.

### Proposed Solution
To address this issue, this PR proposes modifying the plugin to only run the twirpy generator if the .proto file contains services. If a file does not define any services, the plugin will skip generating any code for that file.
